### PR TITLE
In Hub, catch and rethrow all exceptions occuring during login.

### DIFF
--- a/Back-end/src/main/java/invalid/adininspector/adinhub/MongoDBUserSession.java
+++ b/Back-end/src/main/java/invalid/adininspector/adinhub/MongoDBUserSession.java
@@ -1,5 +1,7 @@
 package invalid.adininspector.adinhub;
 
+import com.mongodb.MongoSocketOpenException;
+
 import invalid.adininspector.MongoClientMediator;
 import invalid.adininspector.exceptions.LoginFailureException;
 
@@ -33,17 +35,23 @@ public class MongoDBUserSession implements IUserSession {
 	 * @param username the username to login with
 	 * @param password the password to login with
 	 * @return the new IUserSession object with a logged-in database connection, or null
+	 * @throws LoginFailureException if connecting to or logging into the MongoDB failed  
 	 */
-	public static IUserSession createUserSession(String username, String password) {
+	public static IUserSession createUserSession(String username, String password) throws LoginFailureException {
 		MongoDBUserSession m = new MongoDBUserSession();
 		try {
 			m.setMongoClientMediator(new MongoClientMediator(username, password));
 			m.getAvailableCollections(); // check if login succeeded
 			return m;
 		} catch (LoginFailureException e) {
-			System.err.println("createUserSession: login failed; u: " + username + "pw: " + password);
+			System.err.println("MongoDBUserSession.createUserSession: login failed; username: " + username);
 			m = null;
-			return null;
+			throw e;
+		} catch (MongoSocketOpenException e) {
+			System.err.println("MongoDBUserSession.createUserSession failed:");
+			e.printStackTrace();
+			m = null;
+			throw new LoginFailureException(e.toString());
 		}
 	}
 

--- a/Back-end/src/test/java/invalid/adininspector/adinhub/TestHub.java
+++ b/Back-end/src/test/java/invalid/adininspector/adinhub/TestHub.java
@@ -9,6 +9,8 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import invalid.adininspector.exceptions.LoginFailureException;
+
 /**
  * Test those methods of Hub that are not simply pass-through.
  * NOTE: these tests require Hub to access MockMongoDBUserSession().
@@ -34,13 +36,25 @@ public class TestHub {
 
 	//@Test
 	public void testLogin() {
-		String token = hub.login(session, "foo", "bar");
+		String token = null;
+		try {
+			token = hub.login(session, "foo", "bar");
+		} catch (LoginFailureException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
 		assertNotNull(token);
 	}
 
 	//@Test
 	public void testLoginTokenSuccess() {
-		String token = hub.login(session, "foo", "bar");
+		String token = null;
+		try {
+			token = hub.login(session, "foo", "bar");
+		} catch (LoginFailureException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
 		assertNotNull(token);
 		boolean loggedIn = hub.authenticate(session, token);
 		assertTrue(loggedIn);
@@ -48,7 +62,13 @@ public class TestHub {
 	
 	//@Test
 	public void testLoginTokenFail() {
-		String token = hub.login(session, "foo", "bar");
+		String token = null;
+		try {
+			token = hub.login(session, "foo", "bar");
+		} catch (LoginFailureException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
 		assertNotNull(token);
 		boolean loggedIn = hub.authenticate(session, "invalid_token");
 		assertFalse(loggedIn);
@@ -56,7 +76,13 @@ public class TestHub {
 
 	//@Test
 	public void testLogout() {
-		String token = hub.login(session, "foo", "bar");
+		String token = null;
+		try {
+			token = hub.login(session, "foo", "bar");
+		} catch (LoginFailureException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
 		assertNotNull(token);
 		String[] res;
 		//res = hub.getAvailableCollections(session);


### PR DESCRIPTION
In MongoDBUserSession catch MongoSocketOpenException (e.g. for timeout due to MongoDB not running.)
In ClientProtocolHandler, report the exception's detail message to the client.
Removed unused variable. Small whitespace cleanup.